### PR TITLE
Update image resizing to use canvas

### DIFF
--- a/lib/ai/dreaming_feature/presentation/dreaming.dart
+++ b/lib/ai/dreaming_feature/presentation/dreaming.dart
@@ -55,8 +55,8 @@ class _DreamingScreenState extends State<DreamingScreen> {
     if (errorMessage != null) {
       _showError(errorMessage, () {
         vm.clearError();
-        Navigator.of(context).pop();
-        context.go('/ai');
+        context.pop();
+        Navigator.pop(context);
       });
     } else if (itineraries != null) {
       Navigator.of(context).pushReplacement(

--- a/lib/ai/form_feature/presentation/components/plan_trip_button.dart
+++ b/lib/ai/form_feature/presentation/components/plan_trip_button.dart
@@ -13,40 +13,42 @@ class PlanTripButton extends StatelessWidget {
       Expanded(
         child: TextButton(
           style: ButtonStyle(
-              padding: const WidgetStatePropertyAll(
-                EdgeInsets.symmetric(
-                  vertical: 16,
-                  horizontal: 8,
-                ),
+            padding: const WidgetStatePropertyAll(
+              EdgeInsets.symmetric(
+                vertical: 16,
+                horizontal: 8,
               ),
-              shape: WidgetStatePropertyAll(
-                RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8.0),
-                ),
-              ),
-              backgroundColor: WidgetStateProperty.resolveWith((states) {
-                if (states.contains(WidgetState.disabled)) {
-                  return Colors.transparent;
-                }
-
-                if (states.contains(WidgetState.pressed)) {
-                  return Theme.of(context).colorScheme.primaryFixedDim;
-                }
-
-                return Theme.of(context).colorScheme.primary;
-              }),
-              foregroundColor: WidgetStateProperty.resolveWith((states) {
-                return loading
-                    ? Theme.of(context).colorScheme.primary
-                    : Theme.of(context).colorScheme.onPrimary;
-              })),
-          onPressed: loading ? null : onPressed,
-          child: Text(
-            loading ? 'Loading...' : 'Plan my dream trip',
-            style: const TextStyle(
-              fontSize: 18,
             ),
+            shape: WidgetStatePropertyAll(
+              RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8.0),
+              ),
+            ),
+            backgroundColor:
+                WidgetStatePropertyAll(Theme.of(context).colorScheme.primary),
+            foregroundColor:
+                WidgetStatePropertyAll(Theme.of(context).colorScheme.onPrimary),
           ),
+          onPressed: loading ? null : onPressed,
+          child: loading
+              ? Padding(
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 3, horizontal: 0),
+                  child: SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 3,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                  ),
+                )
+              : const Text(
+                  'Plan my dream trip',
+                  style: TextStyle(
+                    fontSize: 18,
+                  ),
+                ),
         ),
       ),
     ]);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,9 +17,13 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:compass/common/utilties.dart';
 import './common/services/navigation.dart';
+import 'package:flutter/foundation.dart';
+
+import './web_setup.dart';
 
 void main() {
   Animate.restartOnHotReload = true;
+  if (kIsWeb) loadPicaScript();
   runApp(const CompassApp());
 }
 

--- a/lib/web_setup.dart
+++ b/lib/web_setup.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/foundation.dart';
+import "package:universal_html/html.dart" as html;
+
+// Load Pica for flutter_image_compress on web
+// See: https://pub.dev/packages/flutter_image_compress#web
+// and example code from this issue: https://github.com/flutter/flutter/issues/126131
+Future<void> loadPicaScript() async {
+  final head = html.window.document.getElementsByTagName('head').first;
+  final scriptElement = html.ScriptElement();
+  scriptElement.src =
+      'https://cdn.jsdelivr.net/npm/pica@9.0.1/dist/pica.min.js';
+  scriptElement.onLoad.listen((event) {
+    debugPrint('Pica loaded');
+  });
+  head.append(scriptElement);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -97,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "706b5707578e0c1b4b7550f64078f0a0f19dec3f50a178ffae7006b0a9ca58fb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -312,6 +328,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.2.1"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.4"
   http:
     dependency: "direct main"
     description:
@@ -781,6 +805,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  universal_html:
+    dependency: "direct main"
+    description:
+      name: universal_html
+      sha256: "56536254004e24d9d8cfdb7dbbf09b74cf8df96729f38a2f5c238163e3d58971"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.4"
+  universal_io:
+    dependency: transitive
+    description:
+      name: universal_io
+      sha256: "1722b2dcc462b4b2f3ee7d188dad008b6eb4c40bbd03a3de451d82c78bba9aad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   transparent_image: ^2.0.1
   image: ^4.2.0
   flutter_image_compress: ^2.3.0
+  universal_html: ^2.2.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Previous code used to resize and compress images was blocking the UI thread. Replacing it with code that uses the GPU.

- [`decodeImageFromlist`](https://api.flutter.dev/flutter/dart-ui/decodeImageFromList.html)
- Resize image by rendering into a `Picture` with width of 250. 
- Get an image by calling `Picture.toImage()` 
- Compress using `pkg: FlutterImageCompress`